### PR TITLE
Create DynamoDB table + GET /classes, enrolled classes

### DIFF
--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Daniel Truonog",
     "DateCreated": "Nov 15, 2023, 12:21 AM",
-    "DateLastModified": "Nov 16, 2023, 03:24 AM",
+    "DateLastModified": "Nov 18, 2023, 07:52 PM",
     "Description": "TitanOnline enrollment service database",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -85,18 +85,6 @@
             },
             "SortKey": {
               "AttributeName": "GSI2_SK",
-              "AttributeType": "S"
-            }
-          },
-          "Projection": {
-            "ProjectionType": "ALL"
-          }
-        },
-        {
-          "IndexName": "GSI3",
-          "KeyAttributes": {
-            "PartitionKey": {
-              "AttributeName": "GSI1_SK",
               "AttributeType": "S"
             }
           },
@@ -232,7 +220,7 @@
             "S": "i#0001"
           },
           "GSI2_SK": {
-            "S": "i#0001"
+            "S": "c#0001"
           }
         },
         {
@@ -249,7 +237,7 @@
             "S": "i#0001"
           },
           "GSI2_SK": {
-            "S": "i#0001"
+            "S": "c#0002"
           }
         },
         {
@@ -274,7 +262,7 @@
             "S": "c#0001"
           },
           "SK": {
-            "S": "s#0001"
+            "S": "s#enrolled#0001"
           },
           "EntityType": {
             "S": "enrollment"
@@ -283,7 +271,7 @@
             "S": "s#0001"
           },
           "GSI1_SK": {
-            "S": "c#0001"
+            "S": "c#enrolled#0001"
           }
         },
         {
@@ -291,19 +279,16 @@
             "S": "c#0001"
           },
           "SK": {
-            "S": "s#enrolled#002"
+            "S": "s#0002"
           },
           "EntityType": {
             "S": "enrollment"
           },
           "GSI1_PK": {
-            "S": "s#enrolled#0002"
-          },
-          "GSI2_SK": {
-            "S": "s#enrolled#002"
+            "S": "s#0002"
           },
           "GSI1_SK": {
-            "S": "c#0001"
+            "S": "c#open#0001"
           }
         },
         {
@@ -320,7 +305,24 @@
             "S": "s#0002"
           },
           "GSI1_SK": {
+            "S": "c#open#0002"
+          }
+        },
+        {
+          "PK": {
             "S": "c#0002"
+          },
+          "SK": {
+            "S": "s#0001"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "GSI1_PK": {
+            "S": "s#0001"
+          },
+          "GSI1_SK": {
+            "S": "c#open#0002"
           }
         }
       ],

--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Daniel Truonog",
     "DateCreated": "Nov 15, 2023, 12:21 AM",
-    "DateLastModified": "Nov 18, 2023, 10:10 PM",
+    "DateLastModified": "Nov 20, 2023, 10:27 PM",
     "Description": "TitanOnline enrollment service database",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -65,6 +65,10 @@
         {
           "AttributeName": "maxEnroll",
           "AttributeType": "N"
+        },
+        {
+          "AttributeName": "Frozen",
+          "AttributeType": "BOOL"
         }
       ],
       "GlobalSecondaryIndexes": [
@@ -166,10 +170,13 @@
             "S": "c#0001"
           },
           "currentEnroll": {
-            "N": "9"
+            "N": "10"
           },
           "maxEnroll": {
             "N": "10"
+          },
+          "Frozen": {
+            "BOOL": false
           }
         },
         {
@@ -206,6 +213,9 @@
           },
           "maxEnroll": {
             "N": "10"
+          },
+          "Frozen": {
+            "BOOL": true
           }
         },
         {

--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Daniel Truonog",
     "DateCreated": "Nov 15, 2023, 12:21 AM",
-    "DateLastModified": "Nov 18, 2023, 07:52 PM",
+    "DateLastModified": "Nov 18, 2023, 10:10 PM",
     "Description": "TitanOnline enrollment service database",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -57,6 +57,14 @@
         {
           "AttributeName": "GSI1_SK",
           "AttributeType": "S"
+        },
+        {
+          "AttributeName": "currentEnroll",
+          "AttributeType": "N"
+        },
+        {
+          "AttributeName": "maxEnroll",
+          "AttributeType": "N"
         }
       ],
       "GlobalSecondaryIndexes": [
@@ -151,20 +159,17 @@
               },
               "Name": {
                 "S": "Game Programming"
-              },
-              "currentEnroll": {
-                "N": "9"
-              },
-              "maxEnroll": {
-                "N": "10"
-              },
-              "EnrollmentFroze": {
-                "BOOL": false
               }
             }
           },
           "GSI1_PK": {
             "S": "c#0001"
+          },
+          "currentEnroll": {
+            "N": "9"
+          },
+          "maxEnroll": {
+            "N": "10"
           }
         },
         {
@@ -190,20 +195,17 @@
               },
               "Name": {
                 "S": "Backeng Engineering "
-              },
-              "currentEnroll": {
-                "N": "9"
-              },
-              "maxEnroll": {
-                "N": "10"
-              },
-              "EnrollmentFroze": {
-                "BOOL": false
               }
             }
           },
           "GSI1_PK": {
             "S": "c#0002"
+          },
+          "currentEnroll": {
+            "N": "9"
+          },
+          "maxEnroll": {
+            "N": "10"
           }
         },
         {
@@ -267,6 +269,22 @@
           "EntityType": {
             "S": "enrollment"
           },
+          "Detail": {
+            "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
+              "CourseCode": {
+                "S": "CPSC386"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Game Programming"
+              }
+            }
+          },
           "GSI1_PK": {
             "S": "s#0001"
           },
@@ -283,6 +301,22 @@
           },
           "EntityType": {
             "S": "enrollment"
+          },
+          "Detail": {
+            "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
+              "CourseCode": {
+                "S": "CPSC386"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Game Programming"
+              }
+            }
           },
           "GSI1_PK": {
             "S": "s#0002"
@@ -301,6 +335,22 @@
           "EntityType": {
             "S": "enrollment"
           },
+          "Detail": {
+            "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
+              "CourseCode": {
+                "S": "CPSC449"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Backeng Engineering "
+              }
+            }
+          },
           "GSI1_PK": {
             "S": "s#0002"
           },
@@ -317,6 +367,22 @@
           },
           "EntityType": {
             "S": "enrollment"
+          },
+          "Detail": {
+            "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
+              "CourseCode": {
+                "S": "CPSC449"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Backeng Engineering "
+              }
+            }
           },
           "GSI1_PK": {
             "S": "s#0001"

--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Daniel Truonog",
     "DateCreated": "Nov 15, 2023, 12:21 AM",
-    "DateLastModified": "Nov 15, 2023, 03:52 AM",
+    "DateLastModified": "Nov 15, 2023, 11:02 PM",
     "Description": "TitanOnline enrollment service database",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -134,17 +134,6 @@
         },
         {
           "PK": {
-            "S": "d#CPSC"
-          },
-          "SK": {
-            "S": "d#CPSC"
-          },
-          "EntityType": {
-            "S": "department"
-          }
-        },
-        {
-          "PK": {
             "S": "c#0001"
           },
           "SK": {
@@ -155,6 +144,9 @@
           },
           "Detail": {
             "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
               "CourseCode": {
                 "S": "CPSC386"
               },
@@ -208,6 +200,9 @@
           },
           "Detail": {
             "M": {
+              "Department": {
+                "S": "Computer Science"
+              },
               "CourseCode": {
                 "S": "CPSC449"
               },

--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -3,7 +3,7 @@
   "ModelMetadata": {
     "Author": "Daniel Truonog",
     "DateCreated": "Nov 15, 2023, 12:21 AM",
-    "DateLastModified": "Nov 15, 2023, 11:02 PM",
+    "DateLastModified": "Nov 16, 2023, 03:24 AM",
     "Description": "TitanOnline enrollment service database",
     "AWSService": "Amazon DynamoDB",
     "Version": "3.0"
@@ -43,15 +43,7 @@
           "AttributeType": "M"
         },
         {
-          "AttributeName": "Dropped",
-          "AttributeType": "BOOL"
-        },
-        {
           "AttributeName": "GSI1_PK",
-          "AttributeType": "S"
-        },
-        {
-          "AttributeName": "GSI1_SK",
           "AttributeType": "S"
         },
         {
@@ -60,6 +52,10 @@
         },
         {
           "AttributeName": "GSI2_SK",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "GSI1_SK",
           "AttributeType": "S"
         }
       ],
@@ -89,6 +85,18 @@
             },
             "SortKey": {
               "AttributeName": "GSI2_SK",
+              "AttributeType": "S"
+            }
+          },
+          "Projection": {
+            "ProjectionType": "ALL"
+          }
+        },
+        {
+          "IndexName": "GSI3",
+          "KeyAttributes": {
+            "PartitionKey": {
+              "AttributeName": "GSI1_SK",
               "AttributeType": "S"
             }
           },
@@ -166,26 +174,9 @@
                 "BOOL": false
               }
             }
-          }
-        },
-        {
-          "PK": {
-            "S": "c#0001"
-          },
-          "SK": {
-            "S": "s#0001"
-          },
-          "EntityType": {
-            "S": "enrollment"
-          },
-          "Dropped": {
-            "BOOL": false
           },
           "GSI1_PK": {
-            "S": "s#0001"
-          },
-          "GSI1_SK": {
-            "S": " 2023-08-15T09:30:45Z"
+            "S": "c#0001"
           }
         },
         {
@@ -222,26 +213,9 @@
                 "BOOL": false
               }
             }
-          }
-        },
-        {
-          "PK": {
-            "S": "c#0002"
-          },
-          "SK": {
-            "S": "s#0001"
-          },
-          "EntityType": {
-            "S": "enrollment"
-          },
-          "Dropped": {
-            "BOOL": false
           },
           "GSI1_PK": {
-            "S": "s#0001"
-          },
-          "GSI1_SK": {
-            "S": "2023-01-01T12:00:00Z"
+            "S": "c#0002"
           }
         },
         {
@@ -276,6 +250,77 @@
           },
           "GSI2_SK": {
             "S": "i#0001"
+          }
+        },
+        {
+          "PK": {
+            "S": "s#0002"
+          },
+          "SK": {
+            "S": "s#0002"
+          },
+          "EntityType": {
+            "S": "student"
+          },
+          "Name": {
+            "S": "Titan Tuffy"
+          },
+          "Email": {
+            "S": "tuffytitan@fullerton.edu"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0001"
+          },
+          "SK": {
+            "S": "s#0001"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "GSI1_PK": {
+            "S": "s#0001"
+          },
+          "GSI1_SK": {
+            "S": "c#0001"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0001"
+          },
+          "SK": {
+            "S": "s#enrolled#002"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "GSI1_PK": {
+            "S": "s#enrolled#0002"
+          },
+          "GSI2_SK": {
+            "S": "s#enrolled#002"
+          },
+          "GSI1_SK": {
+            "S": "c#0001"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0002"
+          },
+          "SK": {
+            "S": "s#0002"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "GSI1_PK": {
+            "S": "s#0002"
+          },
+          "GSI1_SK": {
+            "S": "c#0002"
           }
         }
       ],

--- a/TitanOnline.json
+++ b/TitanOnline.json
@@ -1,0 +1,325 @@
+{
+  "ModelName": "TitanOnline",
+  "ModelMetadata": {
+    "Author": "Daniel Truonog",
+    "DateCreated": "Nov 15, 2023, 12:21 AM",
+    "DateLastModified": "Nov 15, 2023, 03:52 AM",
+    "Description": "TitanOnline enrollment service database",
+    "AWSService": "Amazon DynamoDB",
+    "Version": "3.0"
+  },
+  "DataModel": [
+    {
+      "TableName": "TitanOnlineEnrollment",
+      "KeyAttributes": {
+        "PartitionKey": {
+          "AttributeName": "PK",
+          "AttributeType": "S"
+        },
+        "SortKey": {
+          "AttributeName": "SK",
+          "AttributeType": "S"
+        }
+      },
+      "NonKeyAttributes": [
+        {
+          "AttributeName": "EntityType",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "Name",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "Email",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "DepartmentName",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "Detail",
+          "AttributeType": "M"
+        },
+        {
+          "AttributeName": "Dropped",
+          "AttributeType": "BOOL"
+        },
+        {
+          "AttributeName": "GSI1_PK",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "GSI1_SK",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "GSI2_PK",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "GSI2_SK",
+          "AttributeType": "S"
+        }
+      ],
+      "GlobalSecondaryIndexes": [
+        {
+          "IndexName": "GSI1",
+          "KeyAttributes": {
+            "PartitionKey": {
+              "AttributeName": "GSI1_PK",
+              "AttributeType": "S"
+            },
+            "SortKey": {
+              "AttributeName": "GSI1_SK",
+              "AttributeType": "S"
+            }
+          },
+          "Projection": {
+            "ProjectionType": "ALL"
+          }
+        },
+        {
+          "IndexName": "GSI2",
+          "KeyAttributes": {
+            "PartitionKey": {
+              "AttributeName": "GSI2_PK",
+              "AttributeType": "S"
+            },
+            "SortKey": {
+              "AttributeName": "GSI2_SK",
+              "AttributeType": "S"
+            }
+          },
+          "Projection": {
+            "ProjectionType": "ALL"
+          }
+        }
+      ],
+      "TableData": [
+        {
+          "PK": {
+            "S": "s#0001"
+          },
+          "SK": {
+            "S": "s#0001"
+          },
+          "EntityType": {
+            "S": "student"
+          },
+          "Name": {
+            "S": "Daniel Truong"
+          },
+          "Email": {
+            "S": "danieltruong@fullerton.edu"
+          }
+        },
+        {
+          "PK": {
+            "S": "i#0001"
+          },
+          "SK": {
+            "S": "i#0001"
+          },
+          "EntityType": {
+            "S": "instructor"
+          },
+          "Name": {
+            "S": "Dr ABC"
+          },
+          "Email": {
+            "S": "drabc@fullerton.edu"
+          }
+        },
+        {
+          "PK": {
+            "S": "d#CPSC"
+          },
+          "SK": {
+            "S": "d#CPSC"
+          },
+          "EntityType": {
+            "S": "department"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0001"
+          },
+          "SK": {
+            "S": "c#0001"
+          },
+          "EntityType": {
+            "S": "class"
+          },
+          "Detail": {
+            "M": {
+              "CourseCode": {
+                "S": "CPSC386"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Game Programming"
+              },
+              "currentEnroll": {
+                "N": "9"
+              },
+              "maxEnroll": {
+                "N": "10"
+              },
+              "EnrollmentFroze": {
+                "BOOL": false
+              }
+            }
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0001"
+          },
+          "SK": {
+            "S": "s#0001"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "Dropped": {
+            "BOOL": false
+          },
+          "GSI1_PK": {
+            "S": "s#0001"
+          },
+          "GSI1_SK": {
+            "S": " 2023-08-15T09:30:45Z"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0002"
+          },
+          "SK": {
+            "S": "c#0002"
+          },
+          "EntityType": {
+            "S": "class"
+          },
+          "Detail": {
+            "M": {
+              "CourseCode": {
+                "S": "CPSC449"
+              },
+              "SectionNumber": {
+                "S": "1"
+              },
+              "Name": {
+                "S": "Backeng Engineering "
+              },
+              "currentEnroll": {
+                "N": "9"
+              },
+              "maxEnroll": {
+                "N": "10"
+              },
+              "EnrollmentFroze": {
+                "BOOL": false
+              }
+            }
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0002"
+          },
+          "SK": {
+            "S": "s#0001"
+          },
+          "EntityType": {
+            "S": "enrollment"
+          },
+          "Dropped": {
+            "BOOL": false
+          },
+          "GSI1_PK": {
+            "S": "s#0001"
+          },
+          "GSI1_SK": {
+            "S": "2023-01-01T12:00:00Z"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0001"
+          },
+          "SK": {
+            "S": "i#0001"
+          },
+          "EntityType": {
+            "S": "instructor"
+          },
+          "GSI2_PK": {
+            "S": "i#0001"
+          },
+          "GSI2_SK": {
+            "S": "i#0001"
+          }
+        },
+        {
+          "PK": {
+            "S": "c#0002"
+          },
+          "SK": {
+            "S": "i#0001"
+          },
+          "EntityType": {
+            "S": "instructor"
+          },
+          "GSI2_PK": {
+            "S": "i#0001"
+          },
+          "GSI2_SK": {
+            "S": "i#0001"
+          }
+        }
+      ],
+      "DataAccess": {
+        "MySql": {}
+      },
+      "SampleDataFormats": {
+        "s": [
+          "identifiers",
+          "UUID"
+        ]
+      },
+      "BillingMode": "PROVISIONED",
+      "ProvisionedCapacitySettings": {
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "AutoScalingRead": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        },
+        "AutoScalingWrite": {
+          "ScalableTargetRequest": {
+            "MinCapacity": 1,
+            "MaxCapacity": 10,
+            "ServiceRole": "AWSServiceRoleForApplicationAutoScaling_DynamoDBTable"
+          },
+          "ScalingPolicyConfiguration": {
+            "TargetValue": 70
+          }
+        }
+      }
+    }
+  ]
+}

--- a/enrollment_service/database/schemas.py
+++ b/enrollment_service/database/schemas.py
@@ -20,7 +20,7 @@ class Class(BaseModel):
     instructor_id: int
 
 class Student(BaseModel):
-    id: int
+    id: str
     name: str
     dropped_classes: List[Class] = [] 
 

--- a/enrollment_service/query_helper.py
+++ b/enrollment_service/query_helper.py
@@ -1,0 +1,127 @@
+''' This file contains the query for the enrollment service.'''
+from botocore.exceptions import ClientError
+from boto3.dynamodb.types import TypeDeserializer
+import ast
+deserializer = TypeDeserializer()
+
+ERROR_HELP_STRINGS = {
+    # Common Errors
+    'InternalServerError': 'Internal Server Error, generally safe to retry with exponential back-off',
+    'ProvisionedThroughputExceededException': 'Request rate is too high. If you\'re using a custom retry strategy make sure to retry with exponential back-off.' +
+                                              'Otherwise consider reducing frequency of requests or increasing provisioned capacity for your table or secondary index',
+    'ResourceNotFoundException': 'One of the tables was not found, verify table exists before retrying',
+    'ServiceUnavailable': 'Had trouble reaching DynamoDB. generally safe to retry with exponential back-off',
+    'ThrottlingException': 'Request denied due to throttling, generally safe to retry with exponential back-off',
+    'UnrecognizedClientException': 'The request signature is incorrect most likely due to an invalid AWS access key ID or secret key, fix before retrying',
+    'ValidationException': 'The input fails to satisfy the constraints specified by DynamoDB, fix input before retrying',
+    'RequestLimitExceeded': 'Throughput exceeds the current throughput limit for your account, increase account level throughput before retrying',
+}
+
+def handle_error(error):
+    error_code = error.response['Error']['Code']
+    error_message = error.response['Error']['Message']
+
+    error_help_string = ERROR_HELP_STRINGS[error_code]
+
+    print('[{error_code}] {help_string}. Error message: {error_message}'
+          .format(error_code=error_code,
+                  help_string=error_help_string,
+                  error_message=error_message))
+
+
+
+"""Query for available classes given student id"""
+def query_available_classes(dynamodb_client, student_id):
+    input = {
+        "TableName": "TitanOnlineEnrollment",
+        "IndexName": "GSI1",
+        "KeyConditionExpression": "#ec990 = :ec990 And begins_with(#ec991, :ec991)",
+        "ExpressionAttributeNames": {"#ec990":"GSI1_PK","#ec991":"GSI1_SK"},
+        "ExpressionAttributeValues": {":ec990": {"S":f"s#{student_id}"},":ec991": {"S":"c#open#"}}
+    }
+    try:
+        response = dynamodb_client.query(**input)
+        # Parse data from response
+        items = response['Items']
+        if items:
+            formatted_response = [{'Detail': item['Detail']} for item in items]
+            ids = [{'id': item['PK']['S'].split("c#")[1]} for item in items]
+            python_data = [{ k: deserializer.deserialize(v) if isinstance(v, dict) else v for k, v in item.items()} for item in formatted_response]        
+            final_response = []
+
+            for item in python_data:
+                # append ids from id to item['Detail']
+                item['Detail'].update(ids[python_data.index(item)])
+                final_response.append(item['Detail'])
+            print("Query successful.")
+        else:
+            return None
+
+        return final_response
+
+    except ClientError as error:
+        handle_error(error)
+    except BaseException as error:
+        print("Unknown error while querying: " + error.response['Error']['Message'])
+
+"""Query for enrolled classes given student id"""
+def query_enrolled_classes(dynamodb_client, student_id):
+    input = {
+        "TableName": "TitanOnlineEnrollment",
+        "IndexName": "GSI1",
+        "KeyConditionExpression": "#ec990 = :ec990 And begins_with(#ec991, :ec991)",
+        "ExpressionAttributeNames": {"#ec990":"GSI1_PK","#ec991":"GSI1_SK"},
+        "ExpressionAttributeValues": {":ec990": {"S":f"s#{student_id}"},":ec991": {"S":"c#enrolled#"}}
+    }
+    try:
+        response = dynamodb_client.query(**input)
+        # Parse data from response
+        items = response['Items']
+        if items:
+            formatted_response = [{'Detail': item['Detail']} for item in items]
+            ids = [{'id': item['PK']['S'].split("c#")[1]} for item in items]
+            python_data = [{ k: deserializer.deserialize(v) if isinstance(v, dict) else v for k, v in item.items()} for item in formatted_response]        
+            final_response = []
+
+            for item in python_data:
+                # append ids from id to item['Detail']
+                item['Detail'].update(ids[python_data.index(item)])
+                final_response.append(item['Detail'])
+            print("Query successful.")
+        else:
+            return None
+
+        return final_response
+
+    except ClientError as error:
+        handle_error(error)
+    except BaseException as error:
+        print("Unknown error while querying: " + error.response['Error']['Message'])
+
+
+"""Query for student given student id"""
+def query_student(dynamodb_client, student_id):
+    input = {
+        "TableName": "TitanOnlineEnrollment",
+        "Key": {
+            "PK": {"S":f"s#{student_id}"}, 
+            "SK": {"S":f"s#{student_id}"}
+        }
+    }
+    try:
+        response = dynamodb_client.get_item(**input)
+        # Parse data from response
+        if "Item" in response:
+            item = response['Item']
+            student_data = {k: deserializer.deserialize(v) for k,v in item.items()}
+            # Get rid off PK and SK from student_data and add id as key
+            student_data['id'] = item['PK']['S'].split("s#")[1]
+            student_data = {k: student_data[k] for k in student_data if k not in ['PK', 'SK', 'EntityType']}
+            print("Query successful.")
+        else:
+            return None
+        return student_data
+    except ClientError as error:
+        handle_error(error)
+    except BaseException as error:
+        print("Unknown error while querying: " + error.response['Error']['Message'])

--- a/enrollment_service/routes.py
+++ b/enrollment_service/routes.py
@@ -101,7 +101,9 @@ def enroll_student_in_class(student_id: str, class_id: str, db: sqlite3.Connecti
         if class_id in class_ids:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Student is already enrolled in this class")
     
-    # TODO: check if class is frozen
+    # Check if class is frozen
+    if class_data['Frozen']:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Enrollment is frozen")
     
     # Check if the class is full
     if class_data['currentEnroll'] >= class_data['maxEnroll']:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 pydantic
 jwcrypto==1.5.0
 boto3
+redis


### PR DESCRIPTION
# 1. Create DynamoDB Table
# Description
- This is the JSON model file for DynamoDB Table exported from NoSQL Workbench

# Access Pattern & Diagram

(Note: we'll use Redis for Wait List)

![image](https://github.com/anhduy1202/CPSC449-Project3/assets/58461444/655a3e23-79e3-4b57-a923-600239427d5a)

![image](https://github.com/anhduy1202/CPSC449-Project3/assets/58461444/7d616084-53fb-4d81-aede-d46021476380)

GSI1: index by studentId
GSI2: Index by instructorId

# Usage
- Make sure to [download NoSQL Workbench](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/workbench.settingup.html)
- Import the JSON file to NoSQL Workbench (Import data model -> import NoSQL Model Workbench JSON)
![image](https://github.com/anhduy1202/CPSC449-Project3/assets/58461444/bcf1474d-4d73-4a5a-81a1-4f8d113cb32e)
- Once its imported, go to Visualizer to choose the table, then choose "Commit to Amazon DynamoDB"
- Choose "Add a new DynamoDB local connection" if you haven't, make sure to have Amazon DynamoDB local running on port 5500 first
![image](https://github.com/anhduy1202/CPSC449-Project3/assets/58461444/1575cb7f-2142-430f-9c02-0e6b57f126ba)
- Choose "Commit"
- Now, if you go to "Operation Builder", you should see your saved connection, click "Open" to view your newly created table

# 2. PR #5 : Modify GET /classes, /enrolled
# Description
Working on these 2 endpoints 
![image](https://github.com/anhduy1202/CPSC449-Project3/assets/58461444/ae771041-29f1-42fb-a806-6a718f5537b6)
# Result
- Able to query available classes, enrolled classes
- Handle error when student not found, class not found
# DynamoDB access pattern
<!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Get available classes for a given studentId | GSI1 | PK=studentId and SK begins_with c#open
-- | -- | --
<!--td {border: 1px solid #cccccc;}br {mso-data-placement:same-cell;}-->
Get enrolled classes for a given studentId | GSI1 | PK=studentId and SK begins_with c#enrolled
-- | -- | --

# 3. PR #6 : Add Redis + Update lots of endpoint
#  Completed API Endpoints
```py
# DONE: GET available classes for a student
@router.get("/students/{student_id}/classes", tags=['Student']) 

# DONE: GET currently enrolled classes for a student
@router.get("/students/{student_id}/enrolled", tags=['Student'])

# DONE
# Enrolls a student into an available class,
# or will automatically put the student on an open waitlist for a full class
@router.post("/students/{student_id}/classes/{class_id}/enroll", tags=['Student'])

# DONE: Get waitlist position for a student in a class
@router.get("/students/{student_id}/waitlist/{class_id}", tags=['Waitlist'])

# DONE: remove a student from a waiting list
@router.delete("/students/{student_id}/waitlist/{class_id}", tags=['Waitlist'])

# DONE: Get waitlist for a class
@router.get("/classes/{class_id}/waitlist",tags=['Waitlist'])

# DONE: view current enrollment for class
@router.get("/instructors/{instructor_id}/classes/{class_id}/enrollment", tags=['Instructor'])

# DONE: view students who have dropped the class
@router.get("/instructors/{instructor_id}/classes/{class_id}/drop", tags=['Instructor'])

# DONE: Freeze enrollment for classes
@router.put("/registrar/classes/{class_id}/freeze", tags=['Registrar'])
```

# Todos API Endpoints (WIP)
```py

# TODO
# Have a student drop a class they're enrolled in
@router.delete("/students/classes/{class_id}", tags=['Students drop their own classes'])

# TODO: Instructor administratively drop students
@router.post("/instructors/{instructor_id}/classes/{class_id}/students/{student_id}/drop", tags=['Instructor'])

# TODO: Create a new class
@router.post("/registrar/classes/", response_model=Class, tags=['Registrar'])

# TODO: Remove a class
@router.delete("/registrar/classes/{class_id}", tags=['Registrar'])

# TODO: Change the assigned instructor for a class
@router.put("/registrar/classes/{class_id}/instructors/{instructor_id}", tags=['Registrar'])
```
